### PR TITLE
some modifications by x0

### DIFF
--- a/addon/synthDrivers/_ibmeci.py
+++ b/addon/synthDrivers/_ibmeci.py
@@ -113,14 +113,14 @@ class EciThread(threading.Thread):
 		dll.eciRegisterCallback(handle, callback, None)
 		dll.eciSetOutputBuffer(handle, samples, pointer(buffer))
 		dll.eciSetParam(handle, ECIParam.eciInputType, 1)
-		dll.eciSetParam(handle, ECIParam.eciDictionary, 1) #dictionary off
+		dll.eciSetParam(handle, ECIParam.eciDictionary, 1) #dictionary on
 		self.dictionaryHandle = dll.eciNewDict(handle)
 		dll.eciSetDict(handle, self.dictionaryHandle)
 		#0 = main dictionary
-		if path.exists(path.join(ttsPath, "main.dic")):
-			dll.eciLoadDict(handle, self.dictionaryHandle, 0, path.join(ttsPath, "main.dic"))
-		if path.exists(path.join(ttsPath, "root.dic")):
-			dll.eciLoadDict(handle, self.dictionaryHandle, 1, path.join(ttsPath, "root.dic"))
+		if path.exists(path.join(path.abspath(ttsPath), "main.dic")):
+			dll.eciLoadDict(handle, self.dictionaryHandle, 0, path.join(path.abspath(ttsPath), "main.dic").encode('mbcs'))
+		if path.exists(path.join(path.abspath(ttsPath), "root.dic")):
+			dll.eciLoadDict(handle, self.dictionaryHandle, 1, path.join(path.abspath(ttsPath), "root.dic").encode('mbcs'))
 		params[ECIParam.eciLanguageDialect] = dll.eciGetParam(handle, ECIParam.eciLanguageDialect)
 		started.set()
 		while True:

--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -187,7 +187,7 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 			text = text.replace('quil', 'qil') #Sometimes this string make everything buggy with IBMTTS in French
 		if self._backquoteVoiceTags:
 			#this converts to ansi for anticrash. If this breaks with foreign langs, we can remove it.
-			text = text.replace('`', ' ').encode('mbcs', 'replace') #no embedded commands
+			text = text.encode('mbcs', 'replace')
 			text = b"`pp0 `vv%d %s" % (_ibmeci.getVParam(ECIVoiceParam.eciVolume), text)
 			text = resub(anticrash_res, text)
 		else:

--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -32,12 +32,16 @@ pause_re = re.compile(br'([a-zA-Z])([%s])( |$)' %punctuation)
 time_re = re.compile(br"(\d):(\d+):(\d+)")
 
 anticrash_res = {
-	re.compile(br'\b(|\d+|\W+)(|un|anti|re)c(ae|\xe6)sur', re.I): br'\1\2seizur',
+	re.compile(br'\b(|\d+|\W+)?(|un|anti|re)c(ae|\xe6)sur', re.I): br'\1\2seizur',
 	re.compile(br"\b(|\d+|\W+)h'(r|v)[e]", re.I): br"\1h ' \2 e",
-	# re.compile(r"\b(|\d+|\W+)wed[h]esday", re.I): r"\1wed hesday",
-	re.compile(br'hesday'): b' hesday',
-	re.compile(br"\b(|\d+|\W+)tz[s]che", re.I): br"\1tz sche"
-}
+	re.compile(br"\b(\w+[bdflmnrvzqh])hes([bcdfgjklmnprtw]\w+)\b", re.I): br"\1 hes\2",
+	re.compile(br"(\d):(\d\d[snrt][tdh])", re.I): br"\1 \2",
+	re.compile(br"h'([bdfjkpstvx']+)'([rtv][aeiou]?)", re.I): br"h \1 \2",
+	re.compile(br"(re|un|non|anti)cosp", re.I): br"\1kosp",
+	re.compile(br"(anti|non|re|un)caesure", re.I): br"\1ceasure",
+	re.compile(br"(EUR[A-Z]+)(\d+)", re.I): br"\1 \2",
+	re.compile(br"\b(|\d+|\W+)?t+z[s]che", re.I): br"\1tz sche"
+	}
 
 english_fixes = {
 	re.compile(r'(\w+)\.([a-zA-Z]+)'): r'\1 dot \2',

--- a/buildVars.py
+++ b/buildVars.py
@@ -19,7 +19,7 @@ addon_info = {
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 	"addon_description" : _("""This is the IBMTTS synthesizer driver for NVDA."""),
 	# version
-	"addon_version" : "20.02B1",
+	"addon_version" : "20.02B2",
 	# Author(s)
 	"addon_author" : u"David CM <dhf360@gmail.com> and others",
 	# URL for the add-on documentation support


### PR DESCRIPTION
fixes #12 
fixes #9 
fixes #3
 This pull request allows the root.dic and main.dic files in the same directory as eci.dll to load properly, updates anticrash expressions to the comprehensive set, and fixes the code so that if backquote voice tags are enabled they will actually make it to the synthesizer if NVDA's processing of numbers and symbols doesn't get in the way. The previous code was still replacing them even if the tags were enabled.