### PR TITLE
Fix import for new alpha (future 2021.1)

### DIFF
--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -37,7 +37,7 @@ anticrash_res = {
 	re.compile(br"\b(|\d+|\W+)h'(r|v)[e]", re.I): br"\1h ' \2 e",
 	re.compile(br"\b(\w+[bdflmnrvzqh])hes([bcdfgjklmnprtw]\w+)\b", re.I): br"\1 hes\2",
 	re.compile(br"(\d):(\d\d[snrt][tdh])", re.I): br"\1 \2",
-	re.compile(br"h'([bdfjkpstvx']+)'([rtv][aeiou]?)", re.I): br"h \1 \2",
+	re.compile(br"h'([bdfjklpstvx']+)'([rtv][aeiou]?)", re.I): br"h \1 \2",
 	re.compile(br"(re|un|non|anti)cosp", re.I): br"\1kosp",
 	re.compile(br"(anti|non|re|un)caesure", re.I): br"\1ceasure",
 	re.compile(br"(EUR[A-Z]+)(\d+)", re.I): br"\1 \2",

--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -4,7 +4,7 @@
 #synthDrivers/ibmeci.py
 
 import six, synthDriverHandler, languageHandler, config, os, re
-qtry:
+try:
 	from speech.commands import IndexCommand, CharacterModeCommand, LangChangeCommand, BreakCommand, PitchCommand, RateCommand, VolumeCommand
 except ImportError:
 	from speech import IndexCommand, CharacterModeCommand, LangChangeCommand, BreakCommand, PitchCommand, RateCommand, VolumeCommand
@@ -26,7 +26,7 @@ try: # for python 2.7
 		def notify (cls, synth=None, index=None): pass
 	synthDoneSpeaking = synthIndexReached
 except:
-	from driverHandler import BooleanDriverSetting,NumericDriverSetting
+	from autoSettingsUtils.driverSetting import BooleanDriverSetting,NumericDriverSetting
 	from synthDriverHandler import synthIndexReached, synthDoneSpeaking
 	def unicode(s): return s
 


### PR DESCRIPTION
### Issue
1. In new alpha (future 2021.1) BooleanDriverSetting and NumericDriverSetting cannot be imported anymore from driverHandler (deprecation) but need to be imported from autoSettingsUtils.driverSetting
2. In last commit of this add-on (my contribution), a typo has been introduced in the code: qtry instead of try. Seems that the code was still opened and saved in my editor after I had performed the tests. Sorry.

### Solution
1. Modified the import as recommanded
2. Fixed the typo

### Test

Tested on the following versions:
* NVDA last alpha (Version : source-master-3c1693d)
* NVDA 2020.4
* NVDA 2019.3.1
* NVDA 2019.2.1

IBMTTS works for this 4 versions.
