### PR TITLE
Fixing timing of index events without causing crackling

### DIFF
--- a/addon/synthDrivers/_ibmeci.py
+++ b/addon/synthDrivers/_ibmeci.py
@@ -557,7 +557,7 @@ def endStringEvent():
 	endMarkersCount -=1
 	if endMarkersCount == 0:
 		speaking = False
-		idleTimer = threading.Timer(0.3, idlePlayer)
+		idleTimer = threading.Timer(0.0001, idlePlayer)
 		idleTimer.start()
 
 def idlePlayer():


### PR DESCRIPTION
This is my second attempt of trying to fix indexing without regressing sound quality. This supercedes my previous PR #94. This would fix #22 if accepted.
### My investigation
I digged into the issue of crackling and here is my best understanding why it happens.
1. IBM TTS provides to the driver a buffer that can hold 3300 sampleds.
2. Eloquence outputs sound in chunks of that size.
3. For string "Rate 0" spoken at rate 0, observed chunk sizes are 3300, 3300, 3300, 11. Notice the last short chunk.
4. My first attempt (PR #94) sends those chunks to NVDA player as they arrive. The short chunk is is sent separately without being combined with any other chunks.
5. Apparently Google search revealed that this is a flaw of winMM API, that it doesn't handle short chunks well, thus causing crackling.
Why crackling doesn't happen at current master version? After consuming chunk of size 11, current version doesn't send the short chunk to player right away, but rather buffers it and eventually combines with the following chunk, which happens to be just silence. At the cost of not catching the precise moment when 11 chunk has completed playing and thus degrading index firing precision.
Even though NVDA is going to inevitably switch from winMM to Wasapi, I thought it is still good to have a better understanding of crackling and maybe this will also help in some way with future wasapi versions.

### How this PR fixes indexing without introducing crackling.
Indexing is fixed in the similar way to my previous PR #94, by setting `onDone` callback to `player.feed()` call. If more than 1 index is sent together, then onDone callback would trigger all of them, so no index event will be lost.
On a high level, crackling problem is fixed by delayed flushing of audio chunks. When we come across chunk of size 11 - as in my example above, we would find ourselves in a situation where the previous chunk hasn't been flushed yet (or in other words `player.feed()` hasn't been called on it). This allows us to combine chunk of size 11 with the previous chunk of size 3300 and flush both of them in a single call to `player.feed()`.
More precisely, when we receive a new chunk of audio in `eciCallback()` function, we would check how much audio has already been buffered (in `audioStream`) and how much audio is coming in in the new chunk (variable `lp`). We will only flush `audioStream` if both values are at least `samples*2` or in other words if both values are at least as big as the buffer we use to communicate with eloquence. If this condition is satisfied, we will flush old contents of `audioStream` (which is long enough not to cause crackling), and then we will truncate `audioStream` and buffer in it incoming audio chunk. One more case when we would end up flushing is when there is an index event recorded (e.g. `len(indexes) > 0`) - in this case we have to flush to respect accurate index timing.
This complex condition is written in _ibmeci.py lines 369...375 and I will refer to it as "the condition" below.
To illustrate this further, consider "rate 0" example I mentioned above. Eloquence generates audio in 4 chunks:
* Chunk 0, 3300 samples,
* Chunk 1, 3300 samples,
* Chunk 2, 3300 samples,
* Chunk 3, 11 samples.
* Index
* Chunk 4 (847 samples)
* EndOfString index
Here is how new algorithm would process this sequence:
1. In the beginning `audioStream` is empty.
2. Chunk 0 (size 3300) comes in in `eciCallback()`. Since `audioStream` is empty, the condition evaluates to `False`, and we don't flush anything and simply store new chunk of audio in `audioStream`.
3. Chunk 1 (size 3300) comes in. Now the condition evaluates to `True`, since both buffered data and incoming chunk are equal to buffer size. So we call `pleyStream()` to flush contents of `audioStream`, and after that we clear `audioStream` and store new chunk in it.
4. Chunk 2 (size 3300) comes in. Similar to previous step, the condition still evaluates to true so we execute exactly same steps in the same order.
5. Chunk 3 (size 11) comes in. Now the condition is false, since incoming chunk is too small. We append new chunk to `audioStream` and we don't flush it. At this point, `audioStream` contains two recent chunks, or 3311 samples.
6. Index event comes in. We just store it in global variable `indexes`.
7. Chunk 4 (size 847) comes in. Now the condition evaluates to `True`, since we have index stored in global variable `indexes`. So we call `playStream` to flush `audioStream`, which has 3311 samples at this moment - please note that we just prevented crackling by sending small chunk together with the previous one. Then we again clear `audioStream` and store new chunk there.
8. EndOfString index comes in. When this happens we just call `playStream()` to flush any data still present in `audioStream`, so we would flush 847 samples.

### Alternatives considered
Algorithm presented above is more complicated and harder to reason about. Another approach I considered was to play with buffer size. However no matter what buffer size would be, it will always be possible to find an example, where the last chunk generated for a phrase is going to be small, and thus this will not ultimately solve crackling problem. So the algorithm in this PR seems to be the only solution that effectively prevents sending too small chunks to player, while also respecting timing of index events.

### Testing performed
* Tested on NVDA version 2023.1:
    * Tested on all usecases mentioned in #22, observed no crackling.
    * Tested in combination with Phonetic Punctuation 1.6; IBM TTS fires index events accurately, punctuation earcons are played at the right times.
* Tested on NVDA alpha 28430
    * Tested on all usecases mentioned in #22, observed no crackling.
    * Even though Phonetic Punctuation hasn't been yet ported, I verified that index events fire properly by single letter navigation in Windows explorer (when index events are not fired, NVDA doesn't speak the name of the item after single letter navigation).
