### PR TITLE
Replace deprecated import

### DIFF
--- a/addon/globalPlugins/ibmtts.py
+++ b/addon/globalPlugins/ibmtts.py
@@ -9,7 +9,7 @@ from ctypes import windll
 
 import globalVars, gui, globalPluginHandler, addonHandler
 from logHandler import log
-from gui import SettingsPanel
+from gui.settingsDialogs import SettingsPanel
 from synthDrivers._settingsDB import appConfig
 from ._ibmttsUtils import UpdateHandler, GithubService, guiCopiFiles
 addonHandler.initTranslation()


### PR DESCRIPTION
### Issue
The following warning is found in the log at add-on's initialization:
```
WARNING - gui.__getattr__ (09:45:13.224) - MainThread (13456):
Importing SettingsPanel from here is deprecated. Import SettingsPanel from gui.settingsDialogs instead. 
Stack trace:
  File "nvda.pyw", line 399, in <module>
  File "core.pyc", line 693, in main
  File "globalPluginHandler.pyc", line 30, in initialize
  File "globalPluginHandler.pyc", line 23, in listPlugins
  File "importlib\__init__.pyc", line 127, in import_module
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "C:\Users\Cyrille\AppData\Roaming\nvda\addons\IBMTTS\globalPlugins\ibmtts.py", line 12, in <module>
    from gui import SettingsPanel
  File "<frozen importlib._bootstrap>", line 1032, in _handle_fromlist
  File "gui\__init__.pyc", line 115, in __getattr__
```

### Solution
Use the correct import instruction.
