### PR TITLE
Python 3.11 compatibility

### DIFF
--- a/addon/globalPlugins/_ibmttsUtils.py
+++ b/addon/globalPlugins/_ibmttsUtils.py
@@ -377,7 +377,7 @@ class UpdateHandler:
 		if self.isError:
 			nextTime = RETRY_INTERVAL
 		else:
-			nextTime = CHECK_INTERVAL -(time.time()*1000 -self.state.lastCheck)
+			nextTime = int(CHECK_INTERVAL - (time.time() * 1000 - self.state.lastCheck))
 		if nextTime <= 0:
 			self.autoCheckUpdate()
 		else:

--- a/addon/synthDrivers/_ibmeci.py
+++ b/addon/synthDrivers/_ibmeci.py
@@ -374,7 +374,7 @@ def eciCallback (h, ms, lp, dt):
 class CallbackThread(threading.Thread):
 	def __init__(self):
 		threading.Thread.__init__(self)
-		self.setDaemon(True)
+		self.daemon = True
 
 	def run(self):
 		try:


### PR DESCRIPTION
This PR fixes issues with this add-on when run with Python 3.11 (last alpha).

### Issues

1. An error in the add-on update system:

```
ERROR - globalPluginHandler.initialize (11:18:49.285) - MainThread (17360):
Error initializing global plugin <class 'globalPlugins.ibmtts.GlobalPlugin'>
Traceback (most recent call last):
  File "globalPluginHandler.py", line 32, in initialize
    runningPlugins.add(plugin())
                       ^^^^^^^^
  File "C:\Users\Cyrille\AppData\Roaming\nvda\addons\IBMTTS\globalPlugins\ibmtts.py", line 165, in __init__
    updateHandler.updateTimer()
  File "C:\Users\Cyrille\AppData\Roaming\nvda\addons\IBMTTS\globalPlugins\_ibmttsUtils.py", line 384, in updateTimer
    self.timer = callLater(nextTime, self.autoCheckUpdate)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "core.py", line 929, in callLater
    return wx.CallLater(delay, _callLaterExec, callable, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Cyrille\Documents\DevP\GIT\nvda\.venv\Lib\site-packages\wx\core.py", line 3471, in __init__
    self.Start()
  File "C:\Users\Cyrille\Documents\DevP\GIT\nvda\.venv\Lib\site-packages\wx\core.py", line 3492, in Start
    self.timer.Start(self.millis, wx.TIMER_ONE_SHOT)
TypeError: Timer.Start(): argument 1 has unexpected type 'float'
```

2. A deprecation warning from Python 3.11
```
DEBUGWARNING - Python warning (11:17:13.460) - MainThread (3284):
C:\Users\Cyrille\AppData\Roaming\nvda\addons\IBMTTS\synthDrivers\_ibmeci.py:377: DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead
  self.setDaemon(True)
```

### Solutions
1. Since an integer value is now required for `core.callLater`, convert the value to `int`.
2. Use the daemon attribute as requested.

### Note
To ensure continuity of automatic update, it's important to release a version of this add-on with the update system fixed before people are able to upgrade to NVDA 2024.1 (or even better before 2024.1beta1)



