### PR TITLE
Update help style

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,8 +1,6 @@
 ﻿@charset "utf-8";
 body { 
 font-family : Verdana, Arial, Helvetica, Sans-serif;
-color : #FFFFFF;
-background-color : #000000;
 line-height: 1.2em;
 } 
 h1, h2 {text-align: center}
@@ -26,5 +24,3 @@ a { text-decoration : underline;
 text-decoration : none; 
 }
 a:focus, a:hover {outline: solid}
-:link {color: #0000FF;
-background-color: #FFFFFF}


### PR DESCRIPTION
Hi David

For many years, the add-on template uses a dark text on a clear background and most of the add-ons have used the same style.

IBMTTS driver add-on still uses the old style, i.e. clear text on dark background. For people using inverted color this becomes with a clear background, which may be very uncomfortable.

Could you update the style as proposed in this PR? It is the style of the add-on template.
