### PR TITLE
Fix ctypes argument error in setProsodyParam

### DIFF
--- a/addon/synthDrivers/_ibmeci.py
+++ b/addon/synthDrivers/_ibmeci.py
@@ -472,7 +472,7 @@ def setVParam(pr, vl):
 	param_event.clear()
 
 def setProsodyParam(pr, vl):
-	dll.eciSetVoiceParam(handle, 0, pr, vl)
+	dll.eciSetVoiceParam(handle, 0, pr, int(vl))
 
 def setVariant(v):
 	user32.PostThreadMessageA(eciThreadId, WM_COPYVOICE, v, 0)


### PR DESCRIPTION
It appears that when using the earcons and speech rules add-on in browsers, somehow a prosody parameter of some type other than int makes it to the driver. When this happens, since ctypes refuses to coerce a float to an int by itself, an exception is thrown. This causes NVDA to completely hang when the exception is thrown and all synth threads are locked up.

This PR fixes this hang by simply wrapping the `vl` argument in a call to `int()` when passing to `dll.eciSetVoiceParam`.

Note that, while this makes the earcons and speech rules add-on technically usable with this driver, there is still the matter of indexing, which is a separate issue to be solved. Whether that's via #96 or some other approach, depending on WASAPI, is up to you, but it should be done at some point soon.